### PR TITLE
fix: #6 Refactor: Initialize FastMCP instance globally in server.py

### DIFF
--- a/src/blender_open_mcp/server.py
+++ b/src/blender_open_mcp/server.py
@@ -183,8 +183,12 @@ async def server_lifespan(server: FastMCP) -> AsyncIterator[Dict[str, Any]]:
         _blender_connection = None
     logger.info("BlenderMCP server shut down")
 
-# Server instance (set up later with command-line arguments)
-mcp = None
+# Initialize MCP server instance globally
+mcp = FastMCP(
+    "BlenderOpenMCP",
+    description="Blender integration with local AI models via Ollama",
+    lifespan=server_lifespan
+)
 
 _blender_connection = None
 _polyhaven_enabled = False
@@ -520,17 +524,11 @@ def main():
     args = parser.parse_args()
 
     # Set global variables from command-line arguments
-    global _ollama_url, _ollama_model, mcp
+    global _ollama_url, _ollama_model
     _ollama_url = args.ollama_url
     _ollama_model = args.ollama_model
 
-    # Now create the MCP server instance
-    mcp = FastMCP(
-        "BlenderOpenMCP",
-        description="Blender integration with local AI models via Ollama",
-        lifespan=server_lifespan
-    )
-
+    # MCP instance is already created globally
     mcp.run(host=args.host, port=args.port)
 
 


### PR DESCRIPTION
I've instantiated the `FastMCP` object (`mcp`) at the module level in `src/blender_open_mcp/server.py`. This ensures that `mcp` is a valid FastMCP instance when tool and prompt decorators (`@mcp.tool()`, `@mcp.prompt()`) are processed at module load time.

Previously, `mcp` was initialized to `None` globally and then instantiated within the `main()` function. This would cause an `AttributeError: 'NoneType' object has no attribute 'tool'` when decorators were encountered.

Changes:
- Removed `mcp = None` from global scope.
- Added `mcp = FastMCP(...)` at global scope, after `server_lifespan` definition and before tool/prompt registrations.
- Updated `main()` to remove its local `global mcp` declaration and the local `mcp` instantiation, as it now uses the global instance.

This change fixes the server startup error caused by improper `mcp` initialization order and makes the server script more robust. The `global` statement in `main()` now only pertains to `_ollama_url` and `_ollama_model`.